### PR TITLE
feat(iOS13.4): Add Trackpad Support(iOS13.4 and above)

### DIFF
--- a/pkg/apple/MouseEmulation/CocoaView+MouseSupport.swift
+++ b/pkg/apple/MouseEmulation/CocoaView+MouseSupport.swift
@@ -12,7 +12,7 @@ extension CocoaView {
    }
    
    open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-      mouseHandler.touchesBegan(touches: touches)
+      mouseHandler.touchesBegan(touches: touches, event: event)
    }
    
    open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -20,10 +20,11 @@ extension CocoaView {
    }
    
    open override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
-      mouseHandler.touchesCancelled(touches: touches)
+      mouseHandler.touchesCancelled(touches: touches, event: event)
    }
    
    open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-      mouseHandler.touchesEnded(touches: touches)
+      mouseHandler.touchesEnded(touches: touches, event: event)
    }
+   
 }

--- a/pkg/apple/MouseEmulation/EmulatorTouchMouse.swift
+++ b/pkg/apple/MouseEmulation/EmulatorTouchMouse.swift
@@ -24,7 +24,7 @@ import UIKit
    func handleMouseMove(x: CGFloat, y: CGFloat)
 }
 
-@objcMembers public class EmulatorTouchMouseHandler: NSObject {
+@objcMembers public class EmulatorTouchMouseHandler: NSObject, UIPointerInteractionDelegate {
    enum MouseHoldState {
       case notHeld, wait, held
    }
@@ -60,6 +60,8 @@ import UIKit
    
    private let mediumHaptic = UIImpactFeedbackGenerator(style: .medium)
    
+   private var previousPoint: CGPoint = CGPoint(x: 0, y: 0)
+
    public init(view: UIView, delegate: EmulatorTouchMouseHandlerDelegate? = nil) {
       self.view = view
       self.delegate = delegate
@@ -73,6 +75,12 @@ import UIKit
             self?.pendingMouseEvents.append(value)
             self?.processMouseEvents()
          })
+      if #available(iOS 13.4, *) {
+         // get pointer interactions
+         let pointerInteraction = UIPointerInteraction(delegate: self)
+         self.view.addInteraction(pointerInteraction)
+         self.view.isUserInteractionEnabled=true
+      }
    }
    
    private func processMouseEvents() {
@@ -111,8 +119,12 @@ import UIKit
       self.primaryTouch = TouchInfo(touch: primaryTouch.touch, origin: primaryTouch.origin, holdState: .notHeld)
    }
    
-   public func touchesBegan(touches: Set<UITouch>) {
+   public func touchesBegan(touches: Set<UITouch>, event: UIEvent?) {
       guard enabled, let touch = touches.first else {
+         if #available(iOS 13.4, *), let _ = touches.first {
+            let isLeftClick=(event?.buttonMask == UIEvent.ButtonMask.button(1))
+            delegate?.handleMouseClick(isLeftClick: isLeftClick, isPressed: true)
+         }
          return
       }
       if primaryTouch == nil {
@@ -125,8 +137,16 @@ import UIKit
       }
    }
    
-   public func touchesEnded(touches: Set<UITouch>) {
-      guard enabled else { return }
+   public func touchesEnded(touches: Set<UITouch>, event: UIEvent?) {
+      guard enabled else {
+         if #available(iOS 13.4, *) {
+            let isLeftClick=(event?.buttonMask == UIEvent.ButtonMask.button(1))
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+               self?.delegate?.handleMouseClick(isLeftClick: isLeftClick, isPressed: false)
+            }
+         }
+         return
+      }
       for touch in touches {
          if touch == primaryTouch?.touch {
             if touch.tapCount > 0 {
@@ -162,8 +182,14 @@ import UIKit
       }
    }
    
-   public func touchesCancelled(touches: Set<UITouch>) {
-      guard enabled else { return }
+   public func touchesCancelled(touches: Set<UITouch>, event: UIEvent?) {
+      guard enabled else {
+         if #available(iOS 13.4, *) {
+            let isLeftClick=(event?.buttonMask == UIEvent.ButtonMask.button(1))
+            delegate?.handleMouseClick(isLeftClick: isLeftClick, isPressed: false)
+         }
+         return
+      }
       for touch in touches {
          if touch == primaryTouch?.touch {
             endHold()
@@ -178,4 +204,25 @@ import UIKit
       let dy = pointA.y - pointB.y
       return sqrt(dx*dx*dy*dy)
    }
+
+   @available(iOS 13.4, *)
+   public func pointerInteraction(
+       _ interaction: UIPointerInteraction,
+       regionFor request: UIPointerRegionRequest,
+       defaultRegion: UIPointerRegion
+     ) -> UIPointerRegion? {
+        guard !enabled else { return defaultRegion }
+        let a = self.previousPoint
+        let b = request.location
+        delegate?.handleMouseMove(x: b.x-a.x, y: b.y-a.y)
+        self.previousPoint=b
+        return defaultRegion
+   }
+
+   @available(iOS 13.4, *)
+   public func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
+      guard !enabled else { return nil }
+      return UIPointerStyle.hidden()
+   }
+
 }


### PR DESCRIPTION
Merged: https://github.com/libretro/RetroArch/pull/14633

## Description

Adds iPad Trackpad Support to iOS13 Project (for iOS 13.4 and above)

## Related Issues

[[https://github.com/libretro/RetroArch/issues/10769]](https://github.com/libretro/RetroArch/issues/10769)

## Screenshot
This feature makes using windows 98 on iPad (using DosBox-pure core) a lot of fun
![IMG_0722](https://user-images.githubusercontent.com/6903427/202142668-032b1bc7-c803-4327-ab58-3d0259f59e96.PNG)
